### PR TITLE
兼容 PHP 8.2

### DIFF
--- a/src/AdapaySdk/Payment.php
+++ b/src/AdapaySdk/Payment.php
@@ -13,7 +13,7 @@ class Payment extends AdaPay{
     public function __construct()
     {
         parent::__construct();
-        $this->sdk_tools = SDKTools::getInstance();
+        // $this->sdk_tools = SDKTools::getInstance();
     }
 
 

--- a/src/AdapaySdk/Utils/SDKTools.php
+++ b/src/AdapaySdk/Utils/SDKTools.php
@@ -24,14 +24,14 @@ class SDKTools extends AdaPay
         return self::$instance;
     }
 
-    public function post($params=array(), $endpoint){
+    public function post($params, $endpoint){
         $request_params = $this->do_empty_data($params);
         $req_url =  $this->gateWayUrl .$endpoint;
         $header =  $this->get_request_header($req_url, $request_params, self::$header);
         return $this->ada_request->curl_request($req_url, $request_params, $header, $is_json=true);
     }
     
-    public function get($params=array(), $endpoint){
+    public function get($params, $endpoint){
         ksort($params);
         $request_params = $this->do_empty_data($params);
         $req_url =  $this->gateWayUrl . $endpoint ;


### PR DESCRIPTION
在 PHP 8.2 中使用，PHP 抱怨使用定义的函数前面的参数有默认值，后面的参数没默认值，以及未声明属性而动态添加（实际发现没有用到），故作此修改。